### PR TITLE
Change the minimum SHA abbreviation to 3

### DIFF
--- a/environment.c
+++ b/environment.c
@@ -18,7 +18,7 @@ int trust_executable_bit = 1;
 int trust_ctime = 1;
 int check_stat = 1;
 int has_symlinks = 1;
-int minimum_abbrev = 4, default_abbrev = -1;
+int minimum_abbrev = 3, default_abbrev = -1;
 int ignore_case;
 int assume_unchanged;
 int prefer_symlink_refs;


### PR DESCRIPTION
Change the minimum SHA abbreviation to 3

It is reasonable to mine a 3-digit prefix for commits; it is not reasonable to mine a 4 digit prefix. For most projects, this will be sufficient and easy enough; it makes referring to commits by short hash really simple.

Thanks for taking the time to contribute to Git! Please be advised that the
Git community does not use github.com for their contributions. Instead, we use
a mailing list (git@vger.kernel.org) for code submissions, code reviews, and
bug reports. Nevertheless, you can use submitGit to conveniently send your Pull
Requests commits to our mailing list.

Please read the "guidelines for contributing" linked above!
